### PR TITLE
Update README with HuggingFace fallback instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 3. Configure API key:
    - Copy `config.json.example` to `config.json`
    - Edit `config.json` and set your OpenAI API key.
+   - If you don't have an OpenAI key, leave it blank and select the HuggingFace provider when chatting.
 
 4. Run the application:
    ```bash


### PR DESCRIPTION
## Summary
- mention the HuggingFace model as a fallback when no OpenAI API key is available

## Testing
- `pytest -q`